### PR TITLE
Handle missing dashboard sections in post page

### DIFF
--- a/pages/posts/[slug].js
+++ b/pages/posts/[slug].js
@@ -103,7 +103,7 @@ export default function Post({ post }) {
         <div className={STYLES.page.grid}>
           {DASHBOARD_SECTIONS.map(({ id, title, icon }) => (
             <SectionCard key={id} title={title} icon={icon}>
-              {dashboard[id].map((item, index) => (
+              {(dashboard?.[id] ?? []).map((item, index) => (
                 <NewsItem key={index} {...item} />
               ))}
             </SectionCard>


### PR DESCRIPTION
## Summary
- avoid runtime errors when posts omit dashboard sections by safely mapping over available data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894fe8a3c60832c8a3d3efd489c32da