### PR TITLE
Ensure slug derives from filename

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -12,10 +12,12 @@ export function getAllPosts() {
       const fullPath = path.join(postsDirectory, fileName);
       const fileContents = fs.readFileSync(fullPath, 'utf8');
       const parsed = YAML.parse(fileContents);
-      
+
+      const slug = fileName.replace(/\.yaml$/, '');
+
       return {
-        slug: fileName.replace(/\.yaml$/, ''),
         ...parsed.metadata,
+        slug,
         dashboard: parsed.dashboard
       };
     })
@@ -28,10 +30,11 @@ export function getPostBySlug(slug) {
   const fullPath = path.join(postsDirectory, `${slug}.yaml`);
   const fileContents = fs.readFileSync(fullPath, 'utf8');
   const parsed = YAML.parse(fileContents);
+  const realSlug = path.basename(fullPath, '.yaml');
 
   return {
-    slug,
     ...parsed.metadata,
+    slug: realSlug,
     dashboard: parsed.dashboard
   };
 }


### PR DESCRIPTION
## Summary
- ensure post slugs are taken from filenames in API helpers
- avoid metadata overwriting slug by placing slug after spread

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68950011ecb4832cae7a7b42d4f2a1f8