### PR TITLE
Rename Market Movements section to Market Moves

### DIFF
--- a/components/Dashboard.js
+++ b/components/Dashboard.js
@@ -2,7 +2,7 @@ import { TrendingUp, Zap, GitBranch, AlertCircle } from 'lucide-react';
 
 export default function Dashboard({ data }) {
   const sections = [
-    { title: 'Market Movements', icon: TrendingUp, data: data.marketMoves },
+    { title: 'Market Moves', icon: TrendingUp, data: data.marketMoves },
     { title: 'Model Performance', icon: Zap, data: data.modelPerformance },
     { title: 'Key Integrations', icon: GitBranch, data: data.keyIntegrations },
     { title: 'Challenges', icon: AlertCircle, data: data.challenges }


### PR DESCRIPTION
## Summary
- rename "Market Movements" dashboard section to "Market Moves" for a shorter label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895000c9dfc832cbec73c8a36108650